### PR TITLE
FEAT: Move and Copy Meals

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@
 [✔] Move all types into types.ts
 [✔] turn classes into typed objects instead
 [✔] Comportmentalize the app
-[] copy meals
-[] move meals to different day
+[✔] copy meals
+[✔] move meals to different day
 [] dummy api calls, optimistic updates and loading states
 
 ### Styling:

--- a/src/components/DailyView.tsx
+++ b/src/components/DailyView.tsx
@@ -10,10 +10,14 @@ export default function DailyView({
   day,
   AddMealHandler,
   dailyMeals,
+  copyMeal,
+  ToggleCopyMeal,
 }: {
   day: Date;
   AddMealHandler: (newDay: Date, name: string, ingredients: MealIngredientInterface[]) => void;
   dailyMeals: MealInterface[];
+  copyMeal: MealInterface | null;
+  ToggleCopyMeal: (mealToSet: MealInterface) => void
 }) {
   const onSubmit: SubmitHandler<MealFormInputType> = (data) => {
     AddMealHandler(day, data.name, data.ingredients);
@@ -32,6 +36,8 @@ export default function DailyView({
             meal={mealItem}
             prevId={dailyNonDeletedMeals[index - 1]?.id ?? null}
             nextId={dailyNonDeletedMeals[index + 1]?.id || null}
+            copyMeal={copyMeal}
+            ToggleCopyMeal={ToggleCopyMeal}
           />
         )}
       </div>

--- a/src/components/FormComponents/DateInputElement.tsx
+++ b/src/components/FormComponents/DateInputElement.tsx
@@ -1,21 +1,18 @@
 export default function DateInputElement({
-  defaultValue,
   value,
   onChange,
   styles,
 }: {
-  defaultValue: string;
   value: string;
-  onChange: () => void;
+  onChange: (newDate: Date) => void;
   styles?: string;
 }) {
   return (
     <input
       type="date"
       className={`${styles}`}
-      defaultValue={defaultValue}
       value={value}
-      onChange={onChange}
+      onChange={(e) => onChange(new Date(e.target.value))}
     ></input>
   );
 }

--- a/src/components/MealPlanningComponents/DailyViewMeals.tsx
+++ b/src/components/MealPlanningComponents/DailyViewMeals.tsx
@@ -8,10 +8,14 @@ export default function DailyViewMeals({
   meal,
   prevId,
   nextId,
+  copyMeal,
+  ToggleCopyMeal,
 }: {
   meal: MealInterface,
   prevId: string | null,
-  nextId: string | null
+  nextId: string | null,
+  copyMeal: MealInterface | null;
+  ToggleCopyMeal: (mealToSet: MealInterface) => void
 }) {
   const { state } = useAppContext()
   const [editing, setEditing] = useState<boolean>(false)
@@ -57,6 +61,8 @@ export default function DailyViewMeals({
           meal={meal}
           unitsById={unitsById}
           blueprintsById={blueprintsById}
+          copyMeal={copyMeal}
+          ToggleCopyMeal={ToggleCopyMeal}
         />
       }
     </div>

--- a/src/components/MealPlanningComponents/MealInfoView.tsx
+++ b/src/components/MealPlanningComponents/MealInfoView.tsx
@@ -3,13 +3,15 @@ import { IngredientBlueprintInterface, MealInterface, UnitInterface } from '../.
 import EditMealButton from './Local/EditButton';
 
 export default function MealInfoView(
-    { meal, editing, setEditing, blueprintsById, unitsById }
+    { meal, editing, setEditing, blueprintsById, unitsById, copyMeal, ToggleCopyMeal }
         :
         {
             meal: MealInterface, editing: boolean, setEditing: React.Dispatch<React.SetStateAction<boolean>>,
             blueprintsById: { [key: string]: IngredientBlueprintInterface; },
             unitsById:
-            { [key: string]: UnitInterface; }
+            { [key: string]: UnitInterface; },
+            copyMeal: MealInterface | null;
+            ToggleCopyMeal: (mealToSet: MealInterface) => void
         }
 ) {
     const { state, dispatch } = useAppContext()
@@ -31,6 +33,7 @@ export default function MealInfoView(
             <div className="flex justify-between">
                 <div className="text-2xl font-bold">{meal.name}</div>
                 <EditMealButton OnClick={EditMeal} text='Edit' />
+                <button onClick={() => ToggleCopyMeal(meal)}>{copyMeal != null && copyMeal.id === meal.id ? "submit" : "copy"}</button>
                 <div className="flex gap-2">
                     <div className="text-lg">Done</div>
                     <input type="checkbox" checked={meal.isFinished} onChange={ToggleMealDone} />

--- a/src/components/MealPlanningComponents/UpdateMealForm.tsx
+++ b/src/components/MealPlanningComponents/UpdateMealForm.tsx
@@ -65,6 +65,12 @@ export default function UpdateMealForm({
     dispatch({ type: "SET_MEALS", payload: UpdatedMeals });
   };
 
+  const UpdateMealDate = (newDate: Date) => {
+    setEditing(false)
+    const UpdatedMeals = state.meals.map((mealData) => mealData.id == meal.id ? { ...meal, date: newDate.toDateString() } : mealData)
+    dispatch({ type: "SET_MEALS", payload: UpdatedMeals })
+  }
+
   const SwapMealOrder = (swapId: string) => {
     const swapMeal = state.meals.find((mealData) => mealData.id === swapId);
     if (!swapMeal) return;
@@ -192,9 +198,8 @@ export default function UpdateMealForm({
             Delete
           </button>
           <DateInputElement
-            defaultValue={new Date(meal.date).toLocaleDateString("en-CA")}
             value={new Date(meal.date).toLocaleDateString("en-CA")}
-            onChange={() => { }}
+            onChange={UpdateMealDate}
           />
           <div className="flex flex-col">
             {prevId && (

--- a/src/pages/MealPlanPage.tsx
+++ b/src/pages/MealPlanPage.tsx
@@ -3,23 +3,50 @@ import { Value } from "react-calendar/src/shared/types.js";
 import DailyView from "../components/DailyView";
 import { v4 } from "uuid";
 import { useAppContext } from "../context/useAppContext";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { MealIngredientInterface, MealInterface } from "../ts/interfaces";
 import Header from "../components/Global/Header";
 
 function MealPlanPage() {
   const { state, dispatch } = useAppContext()
+
+  const [copyMeal, setCopyMeal] = useState<MealInterface | null>(null)
+  const [mealCopyDates, setMealCopyDates] = useState<string[]>([])
+
+  const ToggleCopyMeal = (mealToSet: MealInterface) => {
+    if (copyMeal === null) {
+      setCopyMeal(mealToSet)
+      return
+    }
+
+    if (copyMeal.id != mealToSet.id) return
+
+    const mealsToAdd: MealInterface[] = []
+    mealCopyDates.forEach(newMealDate => {
+      const maxOrder = state.meals.reduce((acc, cur) => {
+        if (cur.date === newMealDate) {
+          acc = Math.max(acc, cur.order);
+        }
+        return acc;
+      }, 0);
+
+      mealsToAdd.push({ ...mealToSet, date: newMealDate, id: v4(), order: maxOrder + 1, ingredients: mealToSet.ingredients.map(ing => { return { ...ing, id: v4(), bought: false } }) })
+    })
+    dispatch({ type: "SET_MEALS", payload: [...state.meals, ...mealsToAdd] })
+    setCopyMeal(null)
+    setMealCopyDates([])
+  }
+
   const selectedDayExistingMeals = useMemo(() => state.meals.filter(item => !item.isDeleted && item.date === state.selectedDay.toDateString()), [state.selectedDay, state.meals])
   const AddMealHandler = (
     newDay: Date,
     name: string,
     ingredients: MealIngredientInterface[]
   ) => {
-
-    // get the highest order of this day
-    let highest = 0;
-
-    selectedDayExistingMeals.forEach(meal => highest = Math.max(highest, meal.order))
+    const highest = selectedDayExistingMeals.reduce((acc, cur) => {
+      acc = Math.max(acc, cur.order)
+      return acc
+    }, 0)
 
     const newMeal: MealInterface = {
       id: v4(),
@@ -41,8 +68,22 @@ function MealPlanPage() {
       <div className="justify-center flex">
         <Calendar
           className={"react-calendar"}
+          tileContent={
+            ({ date, view }) => view === 'month' && mealCopyDates.includes(date.toDateString()) ? <p className="text-xs">Copy</p> : null
+          }
           onChange={(e: Value) => {
-            if (e instanceof Date) dispatch({ type: 'SET_SELECTED_DAY', payload: e })
+            if (copyMeal == null) {
+              if (e instanceof Date) dispatch({ type: 'SET_SELECTED_DAY', payload: e })
+            } else {
+              if (e instanceof Date) {
+                const dateString: string = e.toDateString()
+                if (mealCopyDates.includes(dateString)) {
+                  setMealCopyDates(mealCopyDates.filter(e => e !== dateString))
+                } else {
+                  setMealCopyDates([...mealCopyDates, dateString])
+                }
+              }
+            }
           }}
         />
       </div>
@@ -51,6 +92,8 @@ function MealPlanPage() {
         day={state.selectedDay}
         AddMealHandler={AddMealHandler}
         dailyMeals={selectedDayExistingMeals.sort((a, b) => a.order - b.order)}
+        copyMeal={copyMeal}
+        ToggleCopyMeal={ToggleCopyMeal}
       />
     </>
   );


### PR DESCRIPTION
Implemented the ability to move meals to another day with a date input field which appears when editing a given meal. Meals can now also be copied by clicking the appropriate copy button, selecting the wanted days in the calendar and then clicking the submit button. 

This implementation is still quite basic and subject to change depending on future UI/UX updates.